### PR TITLE
fixed an error with filter_level

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -444,7 +444,7 @@ class Stream(object):
         if languages:
             self.body['language'] = u','.join(map(str, languages))
         if filter_level:
-            self.body['filter_level'] = filter_level.encode(encoding)
+            self.body['filter_level'] = u','.join(filter_level).encode(encoding)
         self.session.params = {'delimited': 'length'}
         self.host = 'stream.twitter.com'
         self._start(async)


### PR DESCRIPTION
This belongs to ** issue #865**
Setting filter_level for Streaming API as below gives an error:
AttributeError: 'list' object has no attribute 'encode'

Fixed to:
```python
self.body['filter_level'] = u','.join(filter_level).encode(encoding)
```
and tested with Python version: 3.5